### PR TITLE
EU country integration

### DIFF
--- a/gie/agsi_mappings.py
+++ b/gie/agsi_mappings.py
@@ -79,6 +79,7 @@ class AGSICountry(enum.Enum):
     def get_url(self):
         return self.code
 
+    EU = "EU", "EU"
     AT = "AT", "Austria"
     BE = "BE", "Belgium"
     BG = "BG", "Bulgaria"

--- a/gie/alsi_mappings.py
+++ b/gie/alsi_mappings.py
@@ -79,6 +79,7 @@ class ALSICountry(enum.Enum):
     def get_url(self):
         return self.code
 
+    EU = "eu", "EU"
     BE = "BE", "Belgium"
     HR = "HR", "Croatia"
     FR = "FR", "France"


### PR DESCRIPTION
Add EU to ALSI/AGSI country mapping, in order to request EU-wide data via the GIE API.